### PR TITLE
Added a build_depend on message_generation.

### DIFF
--- a/nimbro_log_transport/package.xml
+++ b/nimbro_log_transport/package.xml
@@ -10,6 +10,7 @@
 	<buildtool_depend>catkin</buildtool_depend>
 	<build_depend>roscpp</build_depend>
 	<build_depend>rosgraph_msgs</build_depend>
+	<build_depend>message_generation</build_depend>
 	<run_depend>roscpp</run_depend>
 	<run_depend>rosgraph_msgs</run_depend>
 

--- a/nimbro_service_transport/package.xml
+++ b/nimbro_service_transport/package.xml
@@ -11,6 +11,8 @@
 	<depend>roscpp</depend>
 	<depend>topic_tools</depend>
 
+	<build_depend>message_generation</build_depend>
+
 	<depend>rqt_gui</depend>
 
 	<export>

--- a/nimbro_topic_transport/package.xml
+++ b/nimbro_topic_transport/package.xml
@@ -11,6 +11,8 @@
 	<depend>roscpp</depend>
 	<depend>topic_tools</depend>
 
+	<build_depend>message_generation</build_depend>
+
 	<!-- This is not a hard dependency, the package compiles without plot_msgs. -->
 	<depend>plot_msgs</depend>
 


### PR DESCRIPTION
Added a build_depend on message_generation.

rosjava just refuses to compile the messages if these dependencies are not added. Would be great, if you could add these in the package.xml

Cheers and Thanks in advance,
Daniel Reuter