### PR TITLE
Implement latched topics on TCP

### DIFF
--- a/nimbro_topic_transport/CMakeLists.txt
+++ b/nimbro_topic_transport/CMakeLists.txt
@@ -16,6 +16,10 @@ add_message_files(FILES
 	TopicBandwidth.msg
 )
 
+add_service_files(FILES
+	LatchedMessageRequest.srv
+)
+
 generate_messages(DEPENDENCIES
 	std_msgs
 )

--- a/nimbro_topic_transport/CMakeLists.txt
+++ b/nimbro_topic_transport/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(catkin REQUIRED COMPONENTS
 	topic_tools
 	rostest
 	message_generation
+    std_msgs
+    std_srvs
 )
 
 add_message_files(FILES
@@ -14,10 +16,6 @@ add_message_files(FILES
 	ReceiverStats.msg
 	SenderStats.msg
 	TopicBandwidth.msg
-)
-
-add_service_files(FILES
-	LatchedMessageRequest.srv
 )
 
 generate_messages(DEPENDENCIES

--- a/nimbro_topic_transport/doc/configuration.md
+++ b/nimbro_topic_transport/doc/configuration.md
@@ -67,3 +67,6 @@ parameter is `name`.
  - `resend`: If the sender does not get a message 1.0/`rate` after the last one,
    it will re-send the last received one. (UDP only)
  - `compress`: If true, compress the data on the wire with bz2.
+ - `latch` (bool): This topic should be latched. If you want it to work correctly 
+    (even when the receiver is started later than the sender), you have to launch the
+    helper nodes (look in the example launch files).

--- a/nimbro_topic_transport/launch/tcp_receiver.launch
+++ b/nimbro_topic_transport/launch/tcp_receiver.launch
@@ -1,4 +1,9 @@
 <launch>
+	<arg name="support_latching" default="0" />
+	<arg name="latch_helper_server_port" default="17010" />
+	<arg name="latch_helper_server_hostname" default="localhost" />
+	<arg name="latch_helper_service_server_name" default="tcp_sender" />
+
 	<node name="tcp_receiver" pkg="nimbro_topic_transport" type="tcp_receiver" output="screen">
 		<param name="port" value="17001" />
 
@@ -8,4 +13,10 @@
 		<remap from="/my_first_topic" to="/recv/my_first_topic" />
 		<remap from="/my_second_topic" to="/recv/my_second_topic" />
 	</node>
+
+	<include file="$(find nimbro_topic_transport)/launch/tcp_receiver_latch_helper.launch" if="$(arg support_latching)">
+		<arg name="server_port" value="$(arg latch_helper_server_port)" />
+		<arg name="server_hostname" value="$(arg latch_helper_server_hostname)" />
+		<arg name="service_server_name" value="$(arg latch_helper_service_server_name)" />
+	</include>
 </launch>

--- a/nimbro_topic_transport/launch/tcp_receiver_latch_helper.launch
+++ b/nimbro_topic_transport/launch/tcp_receiver_latch_helper.launch
@@ -1,0 +1,21 @@
+<launch>
+    <arg name="service_server_name" />
+    <arg name="server_hostname" />
+    <arg name="server_port" />
+
+    <node pkg="nimbro_topic_transport" type="tcp_receiver_latch_helper.py" name="tcp_receiver_latch_helper">
+        <param name="service_server_name" value="$(arg service_server_name)" />
+    </node>
+
+    <node name="tcp_receiver_latch_helper_service_client" pkg="nimbro_service_transport" type="service_client">
+        <param name="server" value="$(arg server_hostname)" />
+        <param name="port" value="$(arg server_port)" />
+
+<rosparam subst_value="true">
+services:
+  - name: "$(arg service_server_name)/publish_latched_topics"
+    type: "std_srvs/Empty"
+</rosparam>
+
+    </node>
+</launch>

--- a/nimbro_topic_transport/launch/tcp_sender.launch
+++ b/nimbro_topic_transport/launch/tcp_sender.launch
@@ -1,5 +1,7 @@
 <launch>
 	<arg name="target" default="localhost" />
+	<arg name="support_latching" default="0" />
+	<arg name="latch_helper_server_port" default="17010" />
 
 	<!-- The UDP sender node -->
 	<node name="tcp_sender" pkg="nimbro_topic_transport" type="tcp_sender" output="screen">
@@ -11,4 +13,8 @@
 		<!-- Load the list of topics from a YAML file -->
 		<rosparam command="load" file="$(find nimbro_topic_transport)/launch/topics.yaml" />
 	</node>
+
+	<include file="$(find nimbro_topic_transport)/launch/tcp_sender_latch_helper.launch" if="$(arg support_latching)">
+		<arg name="server_port" value="$(arg latch_helper_server_port)" />
+	</include>
 </launch>

--- a/nimbro_topic_transport/launch/tcp_sender_latch_helper.launch
+++ b/nimbro_topic_transport/launch/tcp_sender_latch_helper.launch
@@ -1,0 +1,7 @@
+<launch>
+    <arg name="server_port" />
+
+    <node name="tcp_sender_latch_helper_service_server" pkg="nimbro_service_transport" type="service_server">
+        <param name="port" value="$(arg server_port)" />
+    </node>
+</launch>

--- a/nimbro_topic_transport/launch/topics.yaml
+++ b/nimbro_topic_transport/launch/topics.yaml
@@ -3,3 +3,4 @@ topics:
    compress: true # enable bz2 compression
    rate: 1.0 # rate limit at 1Hz
  - name: "/my_second_topic"
+   latch: True

--- a/nimbro_topic_transport/package.xml
+++ b/nimbro_topic_transport/package.xml
@@ -9,9 +9,13 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 	<depend>roscpp</depend>
+	<depend>rospy</depend>
 	<depend>topic_tools</depend>
 
 	<build_depend>message_generation</build_depend>
+
+	<depend>std_msgs</depend>
+	<depend>std_srvs</depend>
 
 	<!-- This is not a hard dependency, the package compiles without plot_msgs. -->
 	<depend>plot_msgs</depend>

--- a/nimbro_topic_transport/src/tcp/tcp_packet.h
+++ b/nimbro_topic_transport/src/tcp/tcp_packet.h
@@ -11,7 +11,8 @@ namespace nimbro_topic_transport
 
 enum TCPFlag
 {
-	TCP_FLAG_COMPRESSED = (1 << 0)
+	TCP_FLAG_COMPRESSED = (1 << 0),
+	TCP_FLAG_LATCHED = (1 << 1)
 };
 
 struct TCPHeader

--- a/nimbro_topic_transport/src/tcp/tcp_receiver.cpp
+++ b/nimbro_topic_transport/src/tcp/tcp_receiver.cpp
@@ -10,6 +10,7 @@
 #include "tcp_packet.h"
 #include "../topic_info.h"
 #include <topic_tools/shape_shifter.h>
+#include <std_msgs/String.h>
 
 #include <bzlib.h>
 
@@ -106,6 +107,8 @@ TCPReceiver::TCPReceiver()
 	);
 
 	m_nh.param("topic_prefix", m_topicPrefix, std::string());
+
+    m_pub_ready = m_nh.advertise<std_msgs::String>("/network/receiver_ready", 1, true);
 }
 
 TCPReceiver::~TCPReceiver()
@@ -115,6 +118,10 @@ TCPReceiver::~TCPReceiver()
 void TCPReceiver::run()
 {
 	fd_set fds;
+
+    std_msgs::String readyMessage;
+    readyMessage.data = "";
+    m_pub_ready.publish(readyMessage);
 
 	while(ros::ok())
 	{

--- a/nimbro_topic_transport/src/tcp/tcp_receiver.cpp
+++ b/nimbro_topic_transport/src/tcp/tcp_receiver.cpp
@@ -345,6 +345,10 @@ void TCPReceiver::ClientHandler::run()
 					topic_info::getMsgDef(type)
 				);
 
+				if (header.flags() & TCP_FLAG_LATCHED) {
+					options.latch = true;
+				}
+
 				// It will take subscribers some time to connect to our publisher.
 				// Therefore, latch messages so they will not be lost.
 				// No, this is often unexpected. Instead, wait before publishing.

--- a/nimbro_topic_transport/src/tcp/tcp_receiver.h
+++ b/nimbro_topic_transport/src/tcp/tcp_receiver.h
@@ -65,6 +65,7 @@ private:
 	ros::WallTimer m_statsTimer;
 
 	std::string m_topicPrefix;
+	ros::Publisher m_pub_ready;
 };
 
 }

--- a/nimbro_topic_transport/src/tcp/tcp_receiver_latch_helper.py
+++ b/nimbro_topic_transport/src/tcp/tcp_receiver_latch_helper.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+__author__ = "Martin Pecka <martin.pecka@cvut.cz>"
+
+import rospy
+from std_msgs.msg import String
+from std_srvs.srv import Empty, EmptyRequest
+
+
+class LatchHelper(object):
+    """Helper class that calls the publish_latched_messages service of a remote sender whenever a receiver gets ready."""
+
+    def __init__(self):
+
+        # name of the remote service to be called
+        self._service_server_name = rospy.get_param("~service_server_name")
+
+        self._ready_subscriber = rospy.Subscriber("/network/receiver_ready",
+                                                  String, self.receiver_ready_cb, queue_size=1)
+
+        self._service_server = rospy.ServiceProxy(self._service_server_name + "/publish_latched_messages", Empty)
+
+    def receiver_ready_cb(self, receiver_name_msg):
+        self._service_server(EmptyRequest())
+
+if __name__ == '__main__':
+    rospy.init_node("tcp_receiver_latch_helper")
+    helper = LatchHelper()
+    rospy.spin()

--- a/nimbro_topic_transport/src/tcp/tcp_sender.cpp
+++ b/nimbro_topic_transport/src/tcp/tcp_sender.cpp
@@ -77,6 +77,9 @@ TCPSender::TCPSender()
 		if(entry.hasMember("compress") && ((bool)entry["compress"]) == true)
 			flags |= TCP_FLAG_COMPRESSED;
 
+		if(entry.hasMember("latch") && ((bool)entry["latch"]) == true)
+			flags |= TCP_FLAG_LATCHED;
+
 		boost::function<void(const topic_tools::ShapeShifter::ConstPtr&)> func;
 		func = boost::bind(&TCPSender::send, this, topic, flags, _1);
 
@@ -138,7 +141,10 @@ TCPSender::TCPSender()
 		boost::bind(&TCPSender::updateStats, this)
 	);
 	m_statsTimer.start();
-}	
+
+    m_latchedMessageRequestServer = m_nh.advertiseService(
+            "request_latched_message", &TCPSender::sendLatched, this);
+}
 
 TCPSender::~TCPSender()
 {
@@ -249,6 +255,9 @@ void TCPSender::send(const std::string& topic, int flags, const topic_tools::Sha
 
 	if(flags & TCP_FLAG_COMPRESSED)
 		maxDataSize = size + size / 100 + 1200; // taken from bzip2 docs
+
+	if (flags & TCP_FLAG_LATCHED)
+		this->m_latchedMessages[topic] = std::make_pair(shifter, flags);
 
 	m_packet.resize(
 		sizeof(TCPHeader) + topic.length() + type.length() + maxDataSize
@@ -361,6 +370,23 @@ void TCPSender::updateStats()
 
 	m_pub_stats.publish(m_stats);
 	m_sentBytesInStatsInterval = 0;
+}
+
+bool TCPSender::sendLatched(nimbro_topic_transport::LatchedMessageRequest::Request& request,
+                            nimbro_topic_transport::LatchedMessageRequest::Response& response) {
+
+    if (this->m_latchedMessages.find(request.topic_name) == this->m_latchedMessages.end()) {
+        response.message_sent = false;
+        return true;
+    }
+
+    std::pair<topic_tools::ShapeShifter::ConstPtr, int> record =
+            this->m_latchedMessages.find(request.topic_name)->second;
+
+    this->send(request.topic_name, record.second, record.first);
+    response.message_sent = true;
+
+    return true;
 }
 
 }

--- a/nimbro_topic_transport/src/tcp/tcp_sender.h
+++ b/nimbro_topic_transport/src/tcp/tcp_sender.h
@@ -16,8 +16,9 @@
 
 #include <map>
 
+#include <std_srvs/Empty.h>
+
 #include <nimbro_topic_transport/SenderStats.h>
-#include <nimbro_topic_transport/LatchedMessageRequest.h>
 
 namespace nimbro_topic_transport
 {
@@ -31,8 +32,7 @@ public:
 	bool connect();
 
 	void send(const std::string& topic, int flags, const topic_tools::ShapeShifter::ConstPtr& shifter);
-    bool sendLatched(nimbro_topic_transport::LatchedMessageRequest::Request& request,
-                     nimbro_topic_transport::LatchedMessageRequest::Response& response);
+    bool sendLatched(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 private:
 	void updateStats();
 

--- a/nimbro_topic_transport/src/tcp/tcp_sender.h
+++ b/nimbro_topic_transport/src/tcp/tcp_sender.h
@@ -14,7 +14,10 @@
 #include <config_server/parameter.h>
 #endif
 
+#include <map>
+
 #include <nimbro_topic_transport/SenderStats.h>
+#include <nimbro_topic_transport/LatchedMessageRequest.h>
 
 namespace nimbro_topic_transport
 {
@@ -28,6 +31,8 @@ public:
 	bool connect();
 
 	void send(const std::string& topic, int flags, const topic_tools::ShapeShifter::ConstPtr& shifter);
+    bool sendLatched(nimbro_topic_transport::LatchedMessageRequest::Request& request,
+                     nimbro_topic_transport::LatchedMessageRequest::Response& response);
 private:
 	void updateStats();
 
@@ -43,6 +48,8 @@ private:
 	std::vector<uint8_t> m_packet;
 	std::vector<uint8_t> m_compressionBuf;
 
+	std::map<std::string, std::pair<topic_tools::ShapeShifter::ConstPtr, int> > m_latchedMessages;
+
 #if WITH_CONFIG_SERVER
 	std::map<std::string, boost::shared_ptr<config_server::Parameter<bool>>> m_enableTopic;
 #endif
@@ -53,6 +60,7 @@ private:
 	ros::WallTimer m_statsTimer;
 	uint64_t m_sentBytesInStatsInterval;
 	std::map<std::string, uint64_t> m_topicSendBytesInStatsInteral;
+    ros::ServiceServer m_latchedMessageRequestServer;
 };
 
 }

--- a/nimbro_topic_transport/srv/LatchedMessageRequest.srv
+++ b/nimbro_topic_transport/srv/LatchedMessageRequest.srv
@@ -1,0 +1,3 @@
+string topic_name
+---
+bool message_sent

--- a/nimbro_topic_transport/srv/LatchedMessageRequest.srv
+++ b/nimbro_topic_transport/srv/LatchedMessageRequest.srv
@@ -1,3 +1,0 @@
-string topic_name
----
-bool message_sent


### PR DESCRIPTION
Transmitting a latched topic over the nimbro relay was not supported.

This PR adds several features:

* The publisher on the receiving side will have the "latched" option set if the topic is marked as latched in the YAML config.
* Each TCP sender provides a service (over nimbro) which, when called, republishes latched messages to all latched topics. This makes sure that receivers started after the sender will get even the first latched message.
* The above mentioned service can be called automatically when the receiver is ready.

This PR almost surely breaks ABI, if take care about it. On the other hand, API changes are not breaking compatibility with previous versions.