### PR TITLE
Changed from strtol to strtoll, solves md5sum mismatch on RPi3

### DIFF
--- a/nimbro_service_transport/src/tcp/client_handler.cpp
+++ b/nimbro_service_transport/src/tcp/client_handler.cpp
@@ -221,7 +221,7 @@ void ClientHandler::sendAvailableServices()
 				break;
 			}
 			std::string md5_part = md5sum.substr(8*i, 8);
-			uint32_t md5_num = strtol(md5_part.c_str(), 0, 16);
+			uint32_t md5_num = strtoll(md5_part.c_str(), 0, 16);
 			desc.md5[i] = md5_num;
 		}
 

--- a/nimbro_topic_transport/src/topic_info.cpp
+++ b/nimbro_topic_transport/src/topic_info.cpp
@@ -103,7 +103,7 @@ void packMD5(const std::string& str, LEValue< 4 >* dest)
 	for(int i = 0; i < 4; ++i)
 	{
 		std::string md5_part = str.substr(8*i, 8);
-		uint32_t md5_num = strtol(md5_part.c_str(), 0, 16);
+		uint32_t md5_num = strtoll(md5_part.c_str(), 0, 16);
 		dest[i] = md5_num;
 	}
 }

--- a/nimbro_topic_transport/src/udp/topic_sender.cpp
+++ b/nimbro_topic_transport/src/udp/topic_sender.cpp
@@ -117,7 +117,7 @@ void TopicSender::send()
 			for(int i = 0; i < 4; ++i)
 			{
 				std::string md5_part = md5.substr(8*i, 8);
-				uint32_t md5_num = strtol(md5_part.c_str(), 0, 16);
+				uint32_t md5_num = strtoll(md5_part.c_str(), 0, 16);
 				m_md5[i] = md5_num;
 			}
 

--- a/nimbro_topic_transport/src/udp/udp_receiver.cpp
+++ b/nimbro_topic_transport/src/udp/udp_receiver.cpp
@@ -196,7 +196,7 @@ void UDPReceiver::handleFinishedMessage(Message* msg, HeaderType* header)
 		for(int i = 0; i < 4; ++i)
 		{
 			std::string md5_part = topic->md5_str.substr(8*i, 8);
-			uint32_t md5_num = strtol(md5_part.c_str(), 0, 16);
+			uint32_t md5_num = strtoll(md5_part.c_str(), 0, 16);
 			topic->md5[i] = md5_num;
 		}
 


### PR DESCRIPTION
Solves md5sum mismatch issue on Raspberry Pi 3.

See Issue #6 