### PR TITLE
Fix missing ros dependencies

### DIFF
--- a/nimbro_cam_transport/package.xml
+++ b/nimbro_cam_transport/package.xml
@@ -8,4 +8,5 @@
 	<buildtool_depend>catkin</buildtool_depend>
 	<depend>image_transport</depend>
 	<depend>roscpp</depend>
+	<depend>cv_bridge</depend>
 </package>

--- a/nimbro_service_transport/package.xml
+++ b/nimbro_service_transport/package.xml
@@ -8,12 +8,14 @@
 	<license>GPLv2</license>
 
 	<buildtool_depend>catkin</buildtool_depend>
-	<depend>roscpp</depend>
-	<depend>topic_tools</depend>
-
+	
 	<build_depend>message_generation</build_depend>
 
-	<depend>rqt_gui</depend>
+	<depend>roscpp</depend>
+	<depend>topic_tools</depend>    
+	<depend>rqt_gui_cpp</depend>
+	<depend>libqt4-dev</depend>
+	<depend>qt4-qmake</depend>
 
 	<!-- soft dependency for unit tests -->
 	<depend>catch_ros</depend>

--- a/nimbro_topic_transport/package.xml
+++ b/nimbro_topic_transport/package.xml
@@ -8,10 +8,15 @@
 	<license>GPLv2</license>
 
 	<buildtool_depend>catkin</buildtool_depend>
-	<depend>roscpp</depend>
-	<depend>topic_tools</depend>
 
 	<build_depend>message_generation</build_depend>
+
+	<depend>roscpp</depend>
+	<depend>topic_tools</depend>
+	<depend>rqt_gui_cpp</depend>
+	<depend>libqt4-dev</depend>
+	<depend>qt4-qmake</depend>
+	<depend>yaml-cpp</depend>
 
 	<!-- This is not a hard dependency, the package compiles without plot_msgs. -->
 	<depend>plot_msgs</depend>
@@ -21,8 +26,6 @@
 
 	<!-- This is not a hard dependency, the package compiles without catch_ros -->
 	<depend>catch_ros</depend>
-
-	<depend>rqt_gui</depend>
 
 	<export>
 		<rqt_gui plugin="${prefix}/rqt_plugin.xml" />


### PR DESCRIPTION
When building from rosdep install, there are missing packages, which cases catkin_make to fail.

With these changes, running catkin_make succeeds with:

```
rosdep install --from-paths src --ignore-src -y \
        --skip-keys=config_server --skip-keys=plot_msgs --skip-keys=catch_ros

catkin_make
```

The --skip-keys are for removing the soft dependencies from other AIS-Bonn repositories.