### PR TITLE
topic_transport: fix pruning bug in depacketizer

### DIFF
--- a/nimbro_topic_transport/src/receiver/depacketizer.cpp
+++ b/nimbro_topic_transport/src/receiver/depacketizer.cpp
@@ -35,10 +35,10 @@ void Depacketizer::addPacket(const Packet::Ptr& packet)
 
 	if(it == m_messageBuffer.end())
 	{
+		pruneMessages();
+
 		m_messageBuffer.push_front(PartialMessage(msg_id));
 		it = m_messageBuffer.begin();
-
-		pruneMessages();
 	}
 
 	handleMessagePacket(it, packet);


### PR DESCRIPTION
Prune first, insert new message afterwards. Should fix #17.